### PR TITLE
use project_id in watsonx request

### DIFF
--- a/src/generate.sql
+++ b/src/generate.sql
@@ -27,7 +27,7 @@ begin
   into response_message, response_header
   from table(HTTP_POST_VERBOSE(
     watsonx.geturl('/text/generation'),
-    json_object('model_id': model_id, 'input': text, 'parameters': parameters format json, 'space_id': watsonx.spaceid),
+    json_object('model_id': model_id, 'input': text, 'parameters': parameters format json, 'project_id': watsonx.projectid),
     json_object('headers': json_object('Authorization': 'Bearer ' concat watsonx.JobBearerToken, 'Content-Type': 'application/json', 'Accept': 'application/json'))
   )) x;
   

--- a/src/infer.sql
+++ b/src/infer.sql
@@ -27,7 +27,7 @@ begin
   select ltrim("generated_text") into watsonx_response
   from json_table(QSYS2.HTTP_POST(
     watsonx.geturl('/' concat id_or_name concat '/text/generation'),
-    json_object('input': text, 'parameters': parameters format json, 'space_id': watsonx.spaceid),
+    json_object('input': text, 'parameters': parameters format json, 'project_id': watsonx.projectId),
     json_object('headers': json_object('Authorization': 'Bearer ' concat watsonx.JobBearerToken, 'Content-Type': 'application/json', 'Accept': 'application/json')) 
   ), 'lax $.results[*]'
   columns(

--- a/src/install.sql
+++ b/src/install.sql
@@ -4,6 +4,7 @@ create or replace variable watsonx.region varchar(16) ccsid 1208 default 'us-sou
 create or replace variable watsonx.apiVersion varchar(10) ccsid 1208 default '2023-07-07';
 create or replace variable watsonx.apikey varchar(100) ccsid 1208 default '';
 create or replace variable watsonx.spaceid varchar(100) ccsid 1208 default '';
+create or replace variable watsonx.projectid varchar(100) ccsid 1208 default '';
 create or replace variable watsonx.JobBearerToken varchar(10000) ccsid 1208 default null;
 create or replace variable watsonx.JobTokenExpires timestamp;
 
@@ -33,6 +34,13 @@ create or replace procedure watsonx.SetSpaceIdForJob(spaceid varchar(100))
   set option usrprf = *user, dynusrprf = *user, commit = *none
 begin
   set watsonx.spaceid = spaceid;
+end;
+
+create or replace procedure watsonx.SetProjectdForJob(projectid varchar(100))
+  program type sub
+  set option usrprf = *user, dynusrprf = *user, commit = *none
+begin
+  set watsonx.projectid = projectid;
 end;
 
 create or replace procedure watsonx.SetBearerTokenForJob(bearer_token varchar(10000), expires integer)

--- a/test/a.sql
+++ b/test/a.sql
@@ -4,7 +4,7 @@
 
 call watsonx.logoutjob();
 call watsonx.setapikeyforjob('');
-call watsonx.setspaceidforjob('');
+call watsonx.setprojectidforjob('');
 
 -- Should return Y
 values watsonx.ShouldGetNewToken();


### PR DESCRIPTION
use `project_id` in watsonx request parameters

TODO:
- update legacy.sql